### PR TITLE
Support local pip installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,4 @@ file for their user on the jumpgate.
 
  - add documentation and examples
  - add install script
+ - update README to reflect changes to installation and run procedures

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,4 @@ path="/opt/jump"
 
 git clone https://github.com/opper/jump $path
 cd $path
-virtualenv venv
-source venv/bin/activate
-pip install -r requirements
+pip install .

--- a/jump
+++ b/jump
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-cd /opt/jump
-source venv/bin/activate
-python menu.py

--- a/jump/__init__.py
+++ b/jump/__init__.py
@@ -1,0 +1,1 @@
+from .menu import Jump

--- a/jump/menu.py
+++ b/jump/menu.py
@@ -100,5 +100,4 @@ def main(args=None):
 
 
 if __name__ == '__main__':
-    import sys
-    main(sys.argv)
+    main()

--- a/jump/menu.py
+++ b/jump/menu.py
@@ -5,11 +5,10 @@ import os
 import subprocess
 from typing import List, Dict
 
-import dotenv
 import requests
-from dialog import Dialog
 
-dotenv.load_dotenv()
+import dotenv
+from dialog import Dialog
 
 
 class Jump:
@@ -90,10 +89,16 @@ class Jump:
                 self.run()
 
 
-if __name__ == '__main__':
+def main(args=None):
+    dotenv.load_dotenv()
     locale.setlocale(locale.LC_ALL, '')
 
     try:
         Jump()
     except KeyboardInterrupt:
         pass
+
+
+if __name__ == '__main__':
+    import sys
+    main(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+
+import setuptools
+
+if __name__ == '__main__':
+    with open("README.md", "r") as fh:
+        long_description = fh.read()
+
+    setuptools.setup(
+        name="jump",
+        version='0.1.0',
+        author="opper",
+        author_email="",
+        description=(
+            "Utility that builds a 2-level menu based on applications and their available environments."
+        ),
+        long_description=long_description,
+        long_description_content_type="text/markdown",
+        url="https://github.com/opper/jump",
+        packages=setuptools.find_packages(),
+        classifiers=(
+            "Programming Language :: Python :: 3",
+            "License :: OSI Approved :: MIT License",
+            "Operating System :: OS Independent",
+        ),
+        entry_points={
+            'console_scripts': [
+                'jump = jump.menu:main'
+            ],
+        },
+        install_requires=['python-dotenv', 'pythondialog', 'requests'],
+        include_package_data=True
+    )


### PR DESCRIPTION
Resolves #5

Changes:
- Added necessary files for pip installation
- Moved source file `menu.py` -> `jump/menu.py`
- Modified `install.sh` to use new installation method
    - virtualenv no longer required
- Removed `run.sh`
    - Jump can be run simply be executing `$ jump`