### PR TITLE
sort environments in 2nd menu display

### DIFF
--- a/jump/menu.py
+++ b/jump/menu.py
@@ -90,14 +90,13 @@ class Jump:
                 self.run()
 
     def sort_servers(self, server: tuple) -> int:
-        if server[0] == 'Staging':
-            return -1
+        weights = {
+            'Staging': -1,
+            'Acceptance': 0,
+            'Production': 1,
+        }
 
-        if server[0] == 'Acceptance':
-            return 0
-
-        if server[0] == 'Production':
-            return 1
+        return weights[server[0]] if server[0] in weights else -1
 
 
 @click.command()

--- a/jump/menu.py
+++ b/jump/menu.py
@@ -3,7 +3,6 @@
 import locale
 import os
 import subprocess
-from typing import Dict, List
 
 import click
 import dotenv
@@ -12,8 +11,8 @@ from dialog import Dialog
 
 
 class Jump:
-    items = []
-    formatted_menu_items = []
+    items: list = []
+    formatted_menu_items: list = []
 
     def __init__(self) -> None:
         self.d: Dialog = Dialog()
@@ -22,15 +21,15 @@ class Jump:
 
     def get_item_list(self) -> None:
         secret_key: str = os.environ.get('AUTH_KEY')
-        extra_headers: Dict = {}
+        extra_headers: dict = {}
 
         if secret_key is not None:
             extra_headers[os.environ.get('AUTH_HEADER')] = secret_key
 
-        self.items: List = requests.get(os.environ.get('ENDPOINT'), headers=extra_headers).json()['items']
+        self.items: list = requests.get(os.environ.get('ENDPOINT'), headers=extra_headers).json()['items']
 
-    def format_items(self, items: List, servers_list: bool = False) -> None:
-        self.formatted_menu_items: List = []
+    def format_items(self, items: list, servers_list: bool = False) -> None:
+        self.formatted_menu_items: list = []
 
         for item in items:
             if servers_list is False and item['in_jumpgate'] is False:
@@ -38,7 +37,7 @@ class Jump:
             else:
                 self.formatted_menu_items.append((item['name'] if not servers_list else item['display_name'], ''))
 
-    def create_menu(self, title: str, items: List, cancel_label: str = 'Back') -> tuple:
+    def create_menu(self, title: str, items: list, cancel_label: str = 'Back') -> tuple:
         return self.d.menu(
             text=title,
             choices=items,
@@ -46,13 +45,13 @@ class Jump:
             cancel_label=cancel_label,
         )
 
-    def get_server_info(self, app: str) -> Dict:
+    def get_server_info(self, app: str) -> dict:
         for item in self.items:
             if item['name'] == app:
                 return item
 
-    def get_server_items(self, app: str, server_name: str) -> Dict:
-        app_object = self.get_server_info(app)
+    def get_server_items(self, app: str, server_name: str) -> dict:
+        app_object: dict = self.get_server_info(app)
 
         for server in app_object['servers']:
             if server['display_name'] == server_name:
@@ -66,17 +65,17 @@ class Jump:
         if code == self.d.OK:
             self.format_items(self.get_server_info(app)['servers'], True)
 
-            code, server = self.create_menu('Choose a server', self.formatted_menu_items)
+            code, server = self.create_menu('Choose a server', sorted(self.formatted_menu_items, key=sort_servers))
 
             if code == self.d.CANCEL:
                 self.run()
             else:
-                server_info = self.get_server_items(app, server)
+                server_info: dict = self.get_server_items(app, server)
 
                 if server_info['is_serverpilot']:
-                    command = 'ssh -p{} {}@{} -t "cd /srv/users/serverpilot/apps/{}; exec /bin/bash -l"'
+                    command: str = 'ssh -p{} {}@{} -t "cd /srv/users/serverpilot/apps/{}; exec /bin/bash -l"'
                 else:
-                    command = 'ssh -p{} {}@{}'
+                    command: str = 'ssh -p{} {}@{}'
 
                 subprocess.call(
                     command.format(
@@ -91,11 +90,22 @@ class Jump:
                 self.run()
 
 
+def sort_servers(server: tuple) -> int:
+    if server[0] == 'Staging':
+        return -1
+
+    if server[0] == 'Acceptance':
+        return 0
+
+    if server[0] == 'Production':
+        return 1
+
+
 @click.command()
 @click.option('--env-file')
 def main(env_file):
     if env_file is None:
-        env_file = '{}/.jump.env'.format(os.environ.get('HOME'))
+        env_file: str = '{}/.jump.env'.format(os.environ.get('HOME'))
 
     if os.path.exists(env_file) is False:
         click.secho('Can not find .env file in {}'.format(env_file), fg='red')

--- a/jump/menu.py
+++ b/jump/menu.py
@@ -65,7 +65,7 @@ class Jump:
         if code == self.d.OK:
             self.format_items(self.get_server_info(app)['servers'], True)
 
-            code, server = self.create_menu('Choose a server', sorted(self.formatted_menu_items, key=sort_servers))
+            code, server = self.create_menu('Choose a server', sorted(self.formatted_menu_items, key=self.sort_servers))
 
             if code == self.d.CANCEL:
                 self.run()
@@ -89,16 +89,15 @@ class Jump:
 
                 self.run()
 
+    def sort_servers(self, server: tuple) -> int:
+        if server[0] == 'Staging':
+            return -1
 
-def sort_servers(server: tuple) -> int:
-    if server[0] == 'Staging':
-        return -1
+        if server[0] == 'Acceptance':
+            return 0
 
-    if server[0] == 'Acceptance':
-        return 0
-
-    if server[0] == 'Production':
-        return 1
+        if server[0] == 'Production':
+            return 1
 
 
 @click.command()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__ == '__main__':
 
     setuptools.setup(
         name='pyjump',
-        version='1.1',
+        version='1.2',
         author='opper',
         author_email='alex@opper.nl',
         description=(
@@ -18,6 +18,7 @@ if __name__ == '__main__':
         packages=setuptools.find_packages(),
         classifiers=(
             'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.7',
             'License :: OSI Approved :: MIT License',
             'Operating System :: OS Independent',
         ),


### PR DESCRIPTION
the enviromments will always go like Staging, Acceptance, Production.
the way it's done now is slightly hacky but it's the best i can come
up with because the envs aren't alphabetical or don't follow any 'logic'
other than the important we give to each env (staging being the 'least'
important while production being the most important).